### PR TITLE
Fix bug when deleting multiple images with common layers

### DIFF
--- a/internal/provider/resource_imagesync.go
+++ b/internal/provider/resource_imagesync.go
@@ -234,6 +234,10 @@ func (r *ImageSyncResource) Delete(ctx context.Context, req resource.DeleteReque
 
 		i, err := remote.Image(imgRef, authOpt)
 		if err != nil {
+			if strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
+				// this image layer can't be found, it must have been deleted already!
+				continue
+			}
 			resp.Diagnostics.AddError("failed to get image", err.Error())
 			return
 		}


### PR DESCRIPTION
We had a bug on a specific terraform workflow when deleting multiple images at once which looked like so:

```
│ Error: failed to get image
│ 
│ GET
│ https://europe-docker.pkg.dev/v2/my-gcp-project/my-registry/golang/manifests/1.20.5-bullseye:
│ MANIFEST_UNKNOWN: Failed to fetch "1.20.5-bullseye"
```

My assumption was that this issue was linked to parallelism (terraform runs by default 10 concurrent operations) when deleting images which have layers in common. I was able to reproduce this issue consistently when deleting multiple images which have common layers. Instead of reducing parallelisation, we can simply avoid failing when we're trying to delete a layer which appears to already have been deleted. 

I've tested these modifications locally and the issue seems to have disappeared. 